### PR TITLE
fix: add "GraphQL" to label to avoid conflicts

### DIFF
--- a/run-folder-graphql.js
+++ b/run-folder-graphql.js
@@ -1,6 +1,6 @@
 module.exports.requestGroupActions = [
   {
-    label: 'Send All Requests',
+    label: 'Send All GraphQL Requests',
     action: async (context, data) => {
       const { requests } = data;
 


### PR DESCRIPTION
Currently, the plugin when installed with the 'run-folder' folder, it creates a duplicate entry and it is hard to identify what to click on.